### PR TITLE
feature(setRoute): Possibilita o recebimento de query strings

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -184,6 +184,14 @@ class Request
      */
     public function setRoute($route) : self
     {
+        $query = parse_url($route, PHP_URL_QUERY);
+
+        if ($query) {
+            parse_str($query, $queries);
+
+            $this->addQueries($queries);
+        }
+
         $this->route = ltrim($route, '/');
 
         return $this;

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -407,6 +407,8 @@ class RequestTest extends TestCase
 
         $this->assertArrayHasKey('page', $query);
         $this->assertArrayHasKey('foo', $query);
+        $this->assertEquals('1', $query['page']);
+        $this->assertEquals('bar', $query['foo']);
     }
 
     public function test_set_route_without_query_string()

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -399,6 +399,23 @@ class RequestTest extends TestCase
         $this->assertEquals('true', $api->getQuery()['skipCache']);
     }
 
+    public function test_set_route_with_query_string()
+    {
+        $api = Request::local()->setRoute('http://local.test/?page=1&foo=bar');
+
+        $query = $api->getQuery();
+
+        $this->assertArrayHasKey('page', $query);
+        $this->assertArrayHasKey('foo', $query);
+    }
+
+    public function test_set_route_without_query_string()
+    {
+        $api = Request::local()->setRoute('http://local.test/');
+
+        $this->assertEquals($api->getRoute(), 'http://local.test/');
+    }
+
     protected function genericTestSearch($key)
     {
         $api = Request::url('http://local.test');
@@ -418,22 +435,5 @@ class RequestTest extends TestCase
         $this->expectException(InvalidSearchValueException::class);
         $api->{$key}(['invalid' => '']);
         $api->{$key}(['invalid' => []]);
-    }
-
-    function test_set_route_with_query_string()
-    {
-        $api = Request::local()->setRoute('http://local.test/?page=1&foo=bar');
-
-        $query = $api->getQuery();
-
-        $this->assertArrayHasKey('page', $query);
-        $this->assertArrayHasKey('foo', $query);
-    }
-
-    function test_set_route_without_query_string()
-    {
-        $api = Request::local()->setRoute('http://local.test/');
-
-        $this->assertEquals($api->getRoute(), 'http://local.test/');
     }
 }

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -419,4 +419,21 @@ class RequestTest extends TestCase
         $api->{$key}(['invalid' => '']);
         $api->{$key}(['invalid' => []]);
     }
+
+    function test_set_route_with_query_string()
+    {
+        $api = Request::local()->setRoute('http://local.test/?page=1&foo=bar');
+
+        $query = $api->getQuery();
+
+        $this->assertArrayHasKey('page', $query);
+        $this->assertArrayHasKey('foo', $query);
+    }
+
+    function test_set_route_without_query_string()
+    {
+        $api = Request::local()->setRoute('http://local.test/');
+
+        $this->assertEquals($api->getRoute(), 'http://local.test/');
+    }
 }


### PR DESCRIPTION
## Descrição

Metodo setRoute() agora pode receber na url também query strings.

## Motivação e contexto

Esta alteração foi feita pois quando algum microserviço precisa pingar uma url recebida em algum payload, as query strings recebidas estavam tendo que ser isoladas e preparadas, tornando o fluxo de microserviços bem complicado.

## Como isso foi testado?

Testes unitarios  foram implantados. 