### PR TITLE
dep(Guzzle) Add support to Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "shrikeh/teapot": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
## Descrição

Adiciona `guzzlehttp/guzzle:^7.0` como uma possível versão, devido a dependência ter sido [atualizada no Laravel 8](https://laravel.com/docs/8.x/upgrade#updating-dependencies)

## Motivação e contexto

https://laravel.com/docs/8.x/upgrade#updating-dependencies

## Como isso foi testado?

Local com os testes unitários e também com o interactive shell, executando login e etc.