### PR TITLE
fix(AuthRequest) Add Bearer to Authorization header when jwt

### DIFF
--- a/src/AuthRequest.php
+++ b/src/AuthRequest.php
@@ -113,7 +113,7 @@ class AuthRequest extends Request
 
         $this->addHeader(
             $type === 'bearer' ? 'Authorization' : 'User-Token',
-            $type === 'bearer' ? "Bearer $token" : $token
+            $type === 'bearer' ? "Bearer {$token}" : $token
         );
 
         return $this;

--- a/src/AuthRequest.php
+++ b/src/AuthRequest.php
@@ -102,12 +102,7 @@ class AuthRequest extends Request
      */
     protected function configureAuthToken(string $type, string $token)
     {
-        $types = [
-            'bearer' => 'Authorization',
-            'user-token' => 'User-Token',
-        ];
-
-        $availableTypes = array_keys($types);
+        $availableTypes = ['bearer', 'user-token'];
 
         if (!in_array($type, $availableTypes)) {
             throw new InvalidTokenTypeException('Invalid Token type. Available: ' . implode(', ', $availableTypes));
@@ -117,8 +112,8 @@ class AuthRequest extends Request
         $this->setAuthTokenType($type);
 
         $this->addHeader(
-            $types[$type],
-            $token
+            $type === 'bearer' ? 'Authorization' : 'User-Token',
+            $type === 'bearer' ? "Bearer $token" : $token
         );
 
         return $this;


### PR DESCRIPTION
## Descrição

Corrige o header "Authorization" quando o tipo de autenticação for JWT.

## Motivação e contexto

Autenticação via jwt não está funcionando devido a estar faltando o texto "Bearer" antes do token.

## Como isso foi testado?

Local com aplicação real.