### PR TITLE
Add setter for User-Agent and avoid search throwing exception

### DIFF
--- a/src/Exceptions/InvalidSearchValueException.php
+++ b/src/Exceptions/InvalidSearchValueException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Yampi\Api\Exceptions;
-
-class InvalidSearchValueException extends BaseException
-{
-}

--- a/src/Request.php
+++ b/src/Request.php
@@ -10,7 +10,6 @@ use Yampi\Api\Exceptions\RequestException;
 use Yampi\Api\Exceptions\ValidationException;
 use Yampi\Api\Exceptions\InvalidMethodException;
 use Yampi\Api\Exceptions\InvalidParamException;
-use Yampi\Api\Exceptions\InvalidSearchValueException;
 
 class Request
 {
@@ -786,7 +785,7 @@ class Request
 
         foreach ($parameter as $field => $value) {
             if (!is_string($value) || empty($value)) {
-                throw new InvalidSearchValueException('Search value must be a not empty string', $this);
+                continue;
             }
 
             $values[] = $field . ':' . $value;

--- a/src/Request.php
+++ b/src/Request.php
@@ -160,6 +160,19 @@ class Request
     }
 
     /**
+     * Set User-Agent being used for all requests
+     *
+     * @param string $userAgent
+     * @return self
+     */
+    public function setUserAgent(string $userAgent) : self
+    {
+        $this->userAgent = $userAgent;
+
+        return $this;
+    }
+
+    /**
      * Sets the request's HTTP method.
      *
      * @param string $method

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -8,7 +8,6 @@ use Throwable;
 use Yampi\Api\Exceptions\InvalidIncludeException;
 use Yampi\Api\Exceptions\InvalidMethodException;
 use Yampi\Api\Exceptions\InvalidParamException;
-use Yampi\Api\Exceptions\InvalidSearchValueException;
 
 class RequestTest extends TestCase
 {
@@ -434,8 +433,10 @@ class RequestTest extends TestCase
         $api->{$key}(['new' => 'search'], false);
         $this->assertEquals('new:search', $api->getQuery()[$key]);
 
-        $this->expectException(InvalidSearchValueException::class);
-        $api->{$key}(['invalid' => '']);
-        $api->{$key}(['invalid' => []]);
+        $api->{$key}(['arr' => ['some' => 'thing']], false);
+        $this->assertEquals('', $api->getQuery()[$key]);
+
+        $api->{$key}(['invalid' => ''], false);
+        $this->assertEquals('', $api->getQuery()[$key]);
     }
 }


### PR DESCRIPTION
## Descrição

Remove o throw exception quando não for string em search, e adiciona um setter para User Agent

## Motivação e contexto

Não é necessário jogar uma exception quando não for string, somente remover já resolve. 

## Como isso foi testado?

Local